### PR TITLE
Updated team and added a link to the Windows TCA

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -35,25 +35,31 @@ permalink: /
                     <li>- News von der TUM</li>
                     <li>- Lernräume</li>
                 </ul>
-                <br/>
+                <br />
                 <p>Die App ist für alle TUM-Mitglieder gedacht, kann aber auch ohne TUM-Kennung verwendet werden.</p>
                 <div class="app-download-area">
-                    <div class="app-download-btn wow fadeInUp" data-wow-delay="0.2s">
+                    <div class="app-download-btn wow fadeInUp" data-wow-delay="0.4s">
                         <a href="https://play.google.com/store/apps/details?id=de.tum.in.tumcampus">
                             <i class="fa fa-android"></i>
                             <p class="mb-0"><span>available on</span> Google Store</p>
                         </a>
                     </div>
-                    <div class="app-download-btn wow fadeInDown" data-wow-delay="0.4s">
+                    <div class="app-download-btn wow fadeInUp" data-wow-delay="0.4s">
                         <a href="https://itunes.apple.com/us/app/tum-campus-app/id1217412716?mt=8">
                             <i class="fa fa-apple"></i>
                             <p class="mb-0"><span>available on</span> Apple Store</p>
                         </a>
                     </div>
+                    <div class="app-download-btn wow fadeInUp" data-wow-delay="0.4s">
+                        <a href="https://github.com/COM8/TUM_Campus_App_UWP">
+                            <i class="fa fa-windows"></i>
+                            <p class="mb-0"><span>available on</span> GitHub</p>
+                        </a>
+                    </div>
                 </div>
             </div>
             <div class="col-md-6 text-center">
-                <img src="{{site.baseurl}}/assets/img/screenshots/android_1.png" style="max-height: 600px;"/>
+                <img src="{{site.baseurl}}/assets/img/screenshots/android_1.png" style="max-height: 600px;" />
             </div>
         </div>
     </div>

--- a/_pages/team.html
+++ b/_pages/team.html
@@ -87,6 +87,12 @@ permalink: /team
                 <div class="single-team-member">
                     <div class="member-image">
                         <img src="{{site.baseurl}}/assets/img/team-img/fs.jpg" alt="">
+                        <div class="team-hover-effects">
+                            <div class="team-social-icon">
+                                <a href="https://github.com/com8"><i class="fa fa-github"
+                                        aria-hidden="true"></i></a>
+                            </div>
+                        </div>
                     </div>
                     <div class="member-text">
                         <h4>Fabian Sauter</h4>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1084,6 +1084,9 @@ p {
   position: relative;
   z-index: 1;
   text-align: center;
+  display:table-cell;
+  vertical-align:middle; 
+  text-align:center;
 }
 
 .member-image img {
@@ -1108,7 +1111,6 @@ p {
 .team-hover-effects {
   position: absolute;
   top: 0;
-  left: 0;
   width: 100%;
   height: 100%;
   background-color: rgba(105, 75, 228, 0.8);

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1084,9 +1084,10 @@ p {
   position: relative;
   z-index: 1;
   text-align: center;
-  display:table-cell;
+  display: table;
   vertical-align:middle; 
   text-align:center;
+  margin: 0 auto;
 }
 
 .member-image img {


### PR DESCRIPTION
I've added a link to my team image and fixed the hover layer size for team pictures.
### Before:
![image](https://user-images.githubusercontent.com/11741404/106497007-d3cdab80-64bd-11eb-90f6-7a5fe7a191d8.png)
### After:
![image](https://user-images.githubusercontent.com/11741404/106496977-c9131680-64bd-11eb-93b4-35453a80cc88.png)


Besides that I've also added a link to the GitHub page of the Windows TCA since I pulled it from the MS Store.
### Before:
![image](https://user-images.githubusercontent.com/11741404/106497133-f65fc480-64bd-11eb-854f-49e4a5ba30ee.png)
### After:
![image](https://user-images.githubusercontent.com/11741404/106496780-949f5a80-64bd-11eb-8c10-848bb1a02850.png)

But with that I need a little bit of help since I can not get the flex box to also show a margin between the android and windows button.