### PR TITLE
Team changes

### DIFF
--- a/_pages/team.html
+++ b/_pages/team.html
@@ -139,6 +139,13 @@ permalink: /team
                 <div class="single-team-member">
                     <div class="member-image">
                         <img src="{{site.baseurl}}/assets/img/team-img/bp.jpg" alt="">
+                        <div class="team-hover-effects">
+                            <div class="team-social-icon">
+                                <a href="https://b.pabst.dev"><i class="fa fa-external-link-square" aria-hidden="true"></i></a>
+                                <a href="https://github.com/Bentipa"><i class="fa fa-github" aria-hidden="true"></i></a>
+                                <a href="https://www.linkedin.com/in/benjamin-pabst/"><i class="fa fa-linkedin" aria-hidden="true"></i></a>
+                            </div>
+                        </div>
                     </div>
                     <div class="member-text">
                         <h4>Benjamin Pabst</h4>

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -222,6 +222,10 @@
     .cool_facts_area .col-12:last-of-type .single-cool-fact {
         margin-bottom: 0;
     }
+
+    .member-type {
+        margin: 0 auto;
+    }
 }
 
 @media (min-width: 480px) and (max-width: 767px) {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1100,6 +1100,7 @@ p {
 
 .member-text {
   text-align: center;
+  margin-top: 8px;
 }
 
 .member-text > h4 {
@@ -1114,6 +1115,7 @@ p {
 
 .member-type {
   color: #0076BC;
+  margin-bottom: 16px;
 }
 
 .team-hover-effects {


### PR DESCRIPTION
Adds additional spacing between team member image and name, before:
![image](https://user-images.githubusercontent.com/11789478/194828895-1698fc5e-522a-46a6-b895-261cf5f02a99.png)

Now:
![image](https://user-images.githubusercontent.com/11789478/194828871-23f154cb-5b39-4c92-8c5e-fc4d9121acc2.png)

Also centers team member type header on mobile devices, before:
![image](https://user-images.githubusercontent.com/11789478/194828976-d24d0c02-05bf-41fb-ac8b-7afc429f79c6.png)

Now:
![image](https://user-images.githubusercontent.com/11789478/194829007-3395d70a-c525-4011-b86a-e124631fcec3.png)

I also added some margin below that header to make it look better.

Also adds some links to my profile